### PR TITLE
Add an image to the home tab from a context menu over an image

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,6 @@
 - Click the Tabby context menu button.
 - Go to Tabby Home tab.
 - Image URL should appear in console.
+
+### If everything is broken or your updates aren't appearing
+- Refresh the extension via chrome://extensions/

--- a/README.md
+++ b/README.md
@@ -5,3 +5,17 @@
 - Open the extension from the icon in your browser or go to `localhost:3000/home.html` for the home tab or `localhost:3000/popup.html` for the popup.
 - Whenever you save changes to the code, the above pages should update without you needing to refresh them.
 - To check for syntax issues, run `npm run lint`. It's also recommended that you add the eslint and stylelint plugins to Atom.
+
+### How to debug background script
+- Open chrome://extensions/
+- Under Tabby, click `background page`.
+- This will open the debugger for the background script.
+
+### How to test context menu
+- Open webpage with image.
+- Open Tabby Home tab.
+- Open debugger console.
+- Right click on image in webpage.
+- Click the Tabby context menu button.
+- Go to Tabby Home tab.
+- Image URL should appear in console.

--- a/manifest.json
+++ b/manifest.json
@@ -5,6 +5,9 @@
   "description": "Organize your tabs",
   "version": "1.0",
 
+  "background": {
+    "scripts": ["contextMenus.js"]
+  },
   "browser_action": {
     "default_icon": "icon.png",
     "default_popup": "popup.html"
@@ -12,7 +15,8 @@
   "permissions": [
     "tabs",
     "activeTab",
-    "https://ajax.googleapis.com/"
+    "https://ajax.googleapis.com/",
+    "contextMenus"
   ],
   "content_security_policy": "script-src 'self' 'unsafe-eval' https://ajax.googleapis.com; object-src 'self'"
 }

--- a/src/contextMenus.js
+++ b/src/contextMenus.js
@@ -1,0 +1,7 @@
+chrome.contextMenus.create({
+  title: 'Use URL of image somehow',
+  contexts: ['image'],
+  onclick: function(info) {
+    alert(info.srcUrl)
+  }
+});

--- a/src/contextMenus.js
+++ b/src/contextMenus.js
@@ -1,3 +1,4 @@
+// TODO: store image in local storage to handle case when home tab isn't open
 chrome.contextMenus.create({
   title: 'Use URL of image somehow',
   contexts: ['image'],

--- a/src/contextMenus.js
+++ b/src/contextMenus.js
@@ -2,6 +2,12 @@ chrome.contextMenus.create({
   title: 'Use URL of image somehow',
   contexts: ['image'],
   onclick: function(info) {
-    alert(info.srcUrl)
+    chrome.tabs.query({
+      url: 'chrome-extension://*/home.html'
+    }, function(tabs) {
+      chrome.tabs.sendMessage(tabs[0].id, {
+        url: info.srcUrl
+      });
+    });
   }
 });

--- a/src/home/components/HomePage.css
+++ b/src/home/components/HomePage.css
@@ -11,7 +11,7 @@
   position: absolute;
   top: 100px;
   right: 0;
-  color: #888888;
+  color: var(--white);
   font-size: 16px;
   font-weight: 800;
   transform: rotate(90deg);
@@ -21,7 +21,7 @@
   width: 20em;
   height: 100%;
   position: relative;
-  background: var(--white);
+  background: var(--dark-grey);
   box-shadow: 0 0 0.4em 0 rgba(13, 26, 44, 0.2);
 }
 

--- a/src/home/components/HomePage.css
+++ b/src/home/components/HomePage.css
@@ -1,5 +1,12 @@
 @import 'src/palette.css';
 
+.HomePage {
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  flex-direction: row;
+}
+
 .subHeading {
   position: absolute;
   top: 100px;
@@ -10,12 +17,20 @@
   transform: rotate(90deg);
 }
 
-.boardsPanelContainer {
-  width: 260px;
+.boardsPanel {
+  width: 20em;
   height: 100%;
-  position: absolute;
-  top: 0;
-  left: 0;
+  position: relative;
   background: var(--white);
   box-shadow: 0 0 0.4em 0 rgba(13, 26, 44, 0.2);
+}
+
+.moodboardContainer {
+  width: calc(100% - 20em);
+  height: 100%;
+}
+
+.currentMoodboard {
+  width: 100%;
+  height: 100%;
 }

--- a/src/home/components/HomePage.js
+++ b/src/home/components/HomePage.js
@@ -1,12 +1,18 @@
 import React, { PureComponent } from 'react'
+import Moodboard from 'src/home/components/Moodboard.js'
 
 import styles from 'src/home/components/HomePage.css'
 
 export default class HomePage extends PureComponent {
   render() {
     return (
-      <div className={styles.boardsPanelContainer}>
-        <p className={styles.subHeading}>BOARDS</p>
+      <div className={styles.HomePage}>
+        <div className={styles.boardsPanel}>
+          <p className={styles.subHeading}>BOARDS</p>
+        </div>
+        <div className={styles.moodboardContainer}>
+          <Moodboard className={styles.currentMoodboard} />
+        </div>
       </div>
     )
   }

--- a/src/home/components/Moodboard.css
+++ b/src/home/components/Moodboard.css
@@ -1,0 +1,5 @@
+.moodboardCanvas {
+  width: 100%;
+  height: 100%;
+  background-color: white;
+}

--- a/src/home/components/Moodboard.css
+++ b/src/home/components/Moodboard.css
@@ -1,5 +1,7 @@
+@import 'src/palette.css';
+
 .moodboardCanvas {
   width: 100%;
   height: 100%;
-  background-color: white;
+  background-color: var(--white);
 }

--- a/src/home/components/Moodboard.js
+++ b/src/home/components/Moodboard.js
@@ -8,12 +8,30 @@ export default class Moodboard extends PureComponent {
     className: PropTypes.string
   };
 
+  componentWillMount() {
+    chrome.extension.onMessage.addListener(message => {
+      this.drawImageOnCanvas(message.url)
+    })
+  }
+
+  drawImageOnCanvas(imageUrl) {
+    const context = this.canvas.getContext('2d')
+    const image = new Image()
+    image.onload = function () {
+      context.drawImage(image, 0, 0)
+    }
+    image.src = imageUrl
+  }
+
   render() {
     const computedClass = classNames(this.props.className, styles.Moodboard)
 
     return (
       <div className={computedClass}>
-        <canvas className={styles.moodboardCanvas}></canvas>
+        <canvas
+          className={styles.moodboardCanvas}
+          ref={canvas => (this.canvas = canvas)}
+        ></canvas>
       </div>
     )
   }

--- a/src/home/components/Moodboard.js
+++ b/src/home/components/Moodboard.js
@@ -1,0 +1,20 @@
+import React, { PureComponent, PropTypes } from 'react'
+import classNames from 'classnames'
+
+import styles from 'src/home/components/Moodboard.css'
+
+export default class Moodboard extends PureComponent {
+  static propTypes = {
+    className: PropTypes.string
+  };
+
+  render() {
+    const computedClass = classNames(this.props.className, styles.Moodboard)
+
+    return (
+      <div className={computedClass}>
+        <canvas className={styles.moodboardCanvas}></canvas>
+      </div>
+    )
+  }
+}

--- a/src/homeIndex.js
+++ b/src/homeIndex.js
@@ -8,10 +8,6 @@ import HomePage from 'src/home/components/HomePage'
 
 import 'src/base.css'
 
-chrome.extension.onMessage.addListener(message => {
-  console.log(message.url)
-})
-
 const rootElement = document.getElementById('root')
 function renderApp() {
   ReactDOM.render(

--- a/src/homeIndex.js
+++ b/src/homeIndex.js
@@ -8,6 +8,10 @@ import HomePage from 'src/home/components/HomePage'
 
 import 'src/base.css'
 
+chrome.extension.onMessage.addListener(message => {
+  console.log(message.url)
+})
+
 const rootElement = document.getElementById('root')
 function renderApp() {
   ReactDOM.render(

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,6 +47,7 @@ const commonPlugins = [
   new WriteFilePlugin(),
   new CopyWebpackPlugin([
     { from: 'manifest.json' },
+    { from: path.join(sourceRoot, 'contextMenus.js') },
     { from: 'icon.png' }
   ])
 ]


### PR DESCRIPTION
- Darken sidebar in home tab to add contrast.
- Use CSS Flexbox in home tab layout.
- Add basic Moodboard component with an HTML5 canvas in it.
- Adds dummy button to the right-click context menu for images.
- Clicking on this button will draw the image on the canvas in the home tab. This is done via message passing from a background script to the content script for the home tab.